### PR TITLE
Introduce allow_invalid_utf16 option in Boost JSON

### DIFF
--- a/doc/qbk/io/parsing.qbk
+++ b/doc/qbk/io/parsing.qbk
@@ -107,6 +107,11 @@ with __parse_options__ is possible:
     when reading the input. For example, `std::getline` removes the
     endline characters from the string it produces.]
 
+[caution Enabling the `allow_invalid_utf16` option relaxes strict UTF-16 validation.
+    When enabled, the parser will not throw in case of of illegal leading, trailing or
+	half a surrogate. It will replace UTF-16 code point(s) with the
+    Unicode replacement character.]
+
 [/-----------------------------------------------------------------------------]
 
 [heading Full precision number parsing]

--- a/doc/qbk/io/parsing.qbk
+++ b/doc/qbk/io/parsing.qbk
@@ -109,7 +109,7 @@ with __parse_options__ is possible:
 
 [caution Enabling the `allow_invalid_utf16` option relaxes strict UTF-16 validation.
     When enabled, the parser will not throw in case of of illegal leading, trailing or
-	half a surrogate. It will replace UTF-16 code point(s) with the
+    half a surrogate. It will replace UTF-16 code point(s) with the
     Unicode replacement character.]
 
 [/-----------------------------------------------------------------------------]

--- a/include/boost/json/basic_parser.hpp
+++ b/include/boost/json/basic_parser.hpp
@@ -407,14 +407,17 @@ class basic_parser
         std::integral_constant<bool, StackEmpty_> stack_empty,
         std::integral_constant<bool, AllowComments_> allow_comments,
         /*std::integral_constant<bool, AllowTrailing_>*/ bool allow_trailing,
-        /*std::integral_constant<bool, AllowBadUTF8_>*/ bool allow_bad_utf8);
+        /*std::integral_constant<bool, AllowBadUTF8_>*/ bool allow_bad_utf8,
+        bool allow_bad_utf16);
 
-    template<bool AllowComments_/*,
+    template<bool StackEmpty_, bool AllowComments_/*,
         bool AllowTrailing_, bool AllowBadUTF8_*/>
     const char* resume_value(const char* p,
+        std::integral_constant<bool, StackEmpty_> stack_empty,
         std::integral_constant<bool, AllowComments_> allow_comments,
         /*std::integral_constant<bool, AllowTrailing_>*/ bool allow_trailing,
-        /*std::integral_constant<bool, AllowBadUTF8_>*/ bool allow_bad_utf8);
+        /*std::integral_constant<bool, AllowBadUTF8_>*/ bool allow_bad_utf8,
+        bool allow_bad_utf16);
 
     template<bool StackEmpty_, bool AllowComments_/*,
         bool AllowTrailing_, bool AllowBadUTF8_*/>
@@ -422,7 +425,8 @@ class basic_parser
         std::integral_constant<bool, StackEmpty_> stack_empty,
         std::integral_constant<bool, AllowComments_> allow_comments,
         /*std::integral_constant<bool, AllowTrailing_>*/ bool allow_trailing,
-        /*std::integral_constant<bool, AllowBadUTF8_>*/ bool allow_bad_utf8);
+        /*std::integral_constant<bool, AllowBadUTF8_>*/ bool allow_bad_utf8,
+        bool allow_bad_utf16);
 
     template<bool StackEmpty_, bool AllowComments_/*,
         bool AllowTrailing_, bool AllowBadUTF8_*/>
@@ -430,31 +434,41 @@ class basic_parser
         std::integral_constant<bool, StackEmpty_> stack_empty,
         std::integral_constant<bool, AllowComments_> allow_comments,
         /*std::integral_constant<bool, AllowTrailing_>*/ bool allow_trailing,
-        /*std::integral_constant<bool, AllowBadUTF8_>*/ bool allow_bad_utf8);
+        /*std::integral_constant<bool, AllowBadUTF8_>*/ bool allow_bad_utf8,
+        bool allow_bad_utf16);
 
-    template<int Literal>
-    const char* parse_literal(const char* p,
-        std::integral_constant<int, Literal> literal);
+    template<bool StackEmpty_>
+    const char* parse_null(const char* p,
+        std::integral_constant<bool, StackEmpty_> stack_empty);
+
+    template<bool StackEmpty_>
+    const char* parse_true(const char* p,
+        std::integral_constant<bool, StackEmpty_> stack_empty);
+
+    template<bool StackEmpty_>
+    const char* parse_false(const char* p,
+        std::integral_constant<bool, StackEmpty_> stack_empty);
 
     template<bool StackEmpty_, bool IsKey_/*,
         bool AllowBadUTF8_*/>
     const char* parse_string(const char* p,
         std::integral_constant<bool, StackEmpty_> stack_empty,
         std::integral_constant<bool, IsKey_> is_key,
-        /*std::integral_constant<bool, AllowBadUTF8_>*/ bool allow_bad_utf8);
+        /*std::integral_constant<bool, AllowBadUTF8_>*/ bool allow_bad_utf8,
+        bool allow_bad_utf16);
 
-    template<bool StackEmpty_, char First_, number_precision Numbers_>
+    template<bool StackEmpty_, char First_>
     const char* parse_number(const char* p,
         std::integral_constant<bool, StackEmpty_> stack_empty,
-        std::integral_constant<char, First_> first,
-        std::integral_constant<number_precision, Numbers_> numbers);
+        std::integral_constant<char, First_> first);
 
     template<bool StackEmpty_, bool IsKey_/*,
         bool AllowBadUTF8_*/>
     const char* parse_unescaped(const char* p,
         std::integral_constant<bool, StackEmpty_> stack_empty,
         std::integral_constant<bool, IsKey_> is_key,
-        /*std::integral_constant<bool, AllowBadUTF8_>*/ bool allow_bad_utf8);
+        /*std::integral_constant<bool, AllowBadUTF8_>*/ bool allow_bad_utf8,
+        bool allow_bad_utf16);
 
     template<bool StackEmpty_/*, bool IsKey_,
         bool AllowBadUTF8_*/>
@@ -463,7 +477,8 @@ class basic_parser
         std::size_t total,
         std::integral_constant<bool, StackEmpty_> stack_empty,
         /*std::integral_constant<bool, IsKey_>*/ bool is_key,
-        /*std::integral_constant<bool, AllowBadUTF8_>*/ bool allow_bad_utf8);
+        /*std::integral_constant<bool, AllowBadUTF8_>*/ bool allow_bad_utf8,
+        bool allow_bad_utf16);
 
     // intentionally private
     std::size_t

--- a/include/boost/json/basic_parser.hpp
+++ b/include/boost/json/basic_parser.hpp
@@ -408,7 +408,7 @@ class basic_parser
         std::integral_constant<bool, AllowComments_> allow_comments,
         /*std::integral_constant<bool, AllowTrailing_>*/ bool allow_trailing,
         /*std::integral_constant<bool, AllowBadUTF8_>*/ bool allow_bad_utf8,
-        allow_bad_utf16);
+        bool allow_bad_utf16);
 
     template<bool AllowComments_/*,
         bool AllowTrailing_, bool AllowBadUTF8_*/>
@@ -416,7 +416,7 @@ class basic_parser
         std::integral_constant<bool, AllowComments_> allow_comments,
         /*std::integral_constant<bool, AllowTrailing_>*/ bool allow_trailing,
         /*std::integral_constant<bool, AllowBadUTF8_>*/ bool allow_bad_utf8,
-        allow_bad_utf16);
+        bool allow_bad_utf16);
 
     template<bool StackEmpty_, bool AllowComments_/*,
         bool AllowTrailing_, bool AllowBadUTF8_*/>
@@ -425,7 +425,7 @@ class basic_parser
         std::integral_constant<bool, AllowComments_> allow_comments,
         /*std::integral_constant<bool, AllowTrailing_>*/ bool allow_trailing,
         /*std::integral_constant<bool, AllowBadUTF8_>*/ bool allow_bad_utf8,
-        allow_bad_utf16);
+        bool allow_bad_utf16);
 
     template<bool StackEmpty_, bool AllowComments_/*,
         bool AllowTrailing_, bool AllowBadUTF8_*/>
@@ -434,7 +434,7 @@ class basic_parser
         std::integral_constant<bool, AllowComments_> allow_comments,
         /*std::integral_constant<bool, AllowTrailing_>*/ bool allow_trailing,
         /*std::integral_constant<bool, AllowBadUTF8_>*/ bool allow_bad_utf8,
-        allow_bad_utf16);
+        bool allow_bad_utf16);
 
     template<int Literal>
     const char* parse_literal(const char* p,
@@ -446,7 +446,7 @@ class basic_parser
         std::integral_constant<bool, StackEmpty_> stack_empty,
         std::integral_constant<bool, IsKey_> is_key,
         /*std::integral_constant<bool, AllowBadUTF8_>*/ bool allow_bad_utf8,
-        allow_bad_utf16);
+        bool allow_bad_utf16);
 
     template<bool StackEmpty_, char First_, number_precision Numbers_>
     const char* parse_number(const char* p,
@@ -460,7 +460,7 @@ class basic_parser
         std::integral_constant<bool, StackEmpty_> stack_empty,
         std::integral_constant<bool, IsKey_> is_key,
         /*std::integral_constant<bool, AllowBadUTF8_>*/ bool allow_bad_utf8,
-        allow_bad_utf16);
+        bool allow_bad_utf16);
 
     template<bool StackEmpty_/*, bool IsKey_,
         bool AllowBadUTF8_*/>
@@ -470,7 +470,7 @@ class basic_parser
         std::integral_constant<bool, StackEmpty_> stack_empty,
         /*std::integral_constant<bool, IsKey_>*/ bool is_key,
         /*std::integral_constant<bool, AllowBadUTF8_>*/ bool allow_bad_utf8,
-        allow_bad_utf16);
+        bool allow_bad_utf16);
 
     // intentionally private
     std::size_t

--- a/include/boost/json/basic_parser.hpp
+++ b/include/boost/json/basic_parser.hpp
@@ -408,16 +408,15 @@ class basic_parser
         std::integral_constant<bool, AllowComments_> allow_comments,
         /*std::integral_constant<bool, AllowTrailing_>*/ bool allow_trailing,
         /*std::integral_constant<bool, AllowBadUTF8_>*/ bool allow_bad_utf8,
-        bool allow_bad_utf16);
+        allow_bad_utf16);
 
-    template<bool StackEmpty_, bool AllowComments_/*,
+    template<bool AllowComments_/*,
         bool AllowTrailing_, bool AllowBadUTF8_*/>
     const char* resume_value(const char* p,
-        std::integral_constant<bool, StackEmpty_> stack_empty,
         std::integral_constant<bool, AllowComments_> allow_comments,
         /*std::integral_constant<bool, AllowTrailing_>*/ bool allow_trailing,
         /*std::integral_constant<bool, AllowBadUTF8_>*/ bool allow_bad_utf8,
-        bool allow_bad_utf16);
+        allow_bad_utf16);
 
     template<bool StackEmpty_, bool AllowComments_/*,
         bool AllowTrailing_, bool AllowBadUTF8_*/>
@@ -426,7 +425,7 @@ class basic_parser
         std::integral_constant<bool, AllowComments_> allow_comments,
         /*std::integral_constant<bool, AllowTrailing_>*/ bool allow_trailing,
         /*std::integral_constant<bool, AllowBadUTF8_>*/ bool allow_bad_utf8,
-        bool allow_bad_utf16);
+        allow_bad_utf16);
 
     template<bool StackEmpty_, bool AllowComments_/*,
         bool AllowTrailing_, bool AllowBadUTF8_*/>
@@ -435,19 +434,11 @@ class basic_parser
         std::integral_constant<bool, AllowComments_> allow_comments,
         /*std::integral_constant<bool, AllowTrailing_>*/ bool allow_trailing,
         /*std::integral_constant<bool, AllowBadUTF8_>*/ bool allow_bad_utf8,
-        bool allow_bad_utf16);
+        allow_bad_utf16);
 
-    template<bool StackEmpty_>
-    const char* parse_null(const char* p,
-        std::integral_constant<bool, StackEmpty_> stack_empty);
-
-    template<bool StackEmpty_>
-    const char* parse_true(const char* p,
-        std::integral_constant<bool, StackEmpty_> stack_empty);
-
-    template<bool StackEmpty_>
-    const char* parse_false(const char* p,
-        std::integral_constant<bool, StackEmpty_> stack_empty);
+    template<int Literal>
+    const char* parse_literal(const char* p,
+        std::integral_constant<int, Literal> literal);
 
     template<bool StackEmpty_, bool IsKey_/*,
         bool AllowBadUTF8_*/>
@@ -455,12 +446,13 @@ class basic_parser
         std::integral_constant<bool, StackEmpty_> stack_empty,
         std::integral_constant<bool, IsKey_> is_key,
         /*std::integral_constant<bool, AllowBadUTF8_>*/ bool allow_bad_utf8,
-        bool allow_bad_utf16);
+        allow_bad_utf16);
 
-    template<bool StackEmpty_, char First_>
+    template<bool StackEmpty_, char First_, number_precision Numbers_>
     const char* parse_number(const char* p,
         std::integral_constant<bool, StackEmpty_> stack_empty,
-        std::integral_constant<char, First_> first);
+        std::integral_constant<char, First_> first,
+        std::integral_constant<number_precision, Numbers_> numbers);
 
     template<bool StackEmpty_, bool IsKey_/*,
         bool AllowBadUTF8_*/>
@@ -468,7 +460,7 @@ class basic_parser
         std::integral_constant<bool, StackEmpty_> stack_empty,
         std::integral_constant<bool, IsKey_> is_key,
         /*std::integral_constant<bool, AllowBadUTF8_>*/ bool allow_bad_utf8,
-        bool allow_bad_utf16);
+        allow_bad_utf16);
 
     template<bool StackEmpty_/*, bool IsKey_,
         bool AllowBadUTF8_*/>
@@ -478,7 +470,7 @@ class basic_parser
         std::integral_constant<bool, StackEmpty_> stack_empty,
         /*std::integral_constant<bool, IsKey_>*/ bool is_key,
         /*std::integral_constant<bool, AllowBadUTF8_>*/ bool allow_bad_utf8,
-        bool allow_bad_utf16);
+        allow_bad_utf16);
 
     // intentionally private
     std::size_t

--- a/include/boost/json/basic_parser_impl.hpp
+++ b/include/boost/json/basic_parser_impl.hpp
@@ -564,7 +564,7 @@ do_doc2:
     switch(+opt_.allow_comments |
         (opt_.allow_trailing_commas << 1) |
         (opt_.allow_invalid_utf8 << 2) |
-        (opt_.allow_invalid_utf16 << 4))
+        (opt_.allow_invalid_utf16 << 3))
     {
     // no extensions
     default:
@@ -599,35 +599,35 @@ do_doc2:
         cs = parse_value(cs.begin(), stack_empty, std::true_type(), std::true_type(), std::true_type(), std::false_type());
         break;
     // allow_invalid_utf16
-    case 16:
+    case 8:
         cs = parse_value(cs.begin(), stack_empty, std::false_type(), std::false_type(), std::false_type(), std::true_type());
         break;
     // comments & allow_invalid_utf16
-    case 17:
+    case 9:
         cs = parse_value(cs.begin(), stack_empty, std::true_type(), std::false_type(), std::false_type(), std::true_type());
         break;
     // trailing & allow_invalid_utf16
-    case 18:
+    case 10:
         cs = parse_value(cs.begin(), stack_empty, std::false_type(), std::true_type(), std::false_type(), std::true_type());
         break;
     // skip validation & allow_invalid_utf16
-    case 19:
+    case 11:
         cs = parse_value(cs.begin(), stack_empty, std::false_type(), std::false_type(), std::true_type(), std::true_type());
         break;
     // comments & trailing & allow_invalid_utf16
-    case 20:
+    case 12:
         cs = parse_value(cs.begin(), stack_empty, std::true_type(), std::true_type(), std::false_type(), std::true_type());
         break;
     // comments & skip validation & allow_invalid_utf16
-    case 21:
+    case 13:
         cs = parse_value(cs.begin(), stack_empty, std::true_type(), std::false_type(), std::true_type(), std::true_type());
         break;
     // trailing & skip validation & allow_invalid_utf16
-    case 22:
+    case 14:
         cs = parse_value(cs.begin(), stack_empty, std::false_type(), std::true_type(), std::true_type(), std::true_type());
         break;
     // comments & trailing & skip validation & allow_invalid_utf16
-    case 23:
+    case 15:
         cs = parse_value(cs.begin(), stack_empty, std::true_type(), std::true_type(), std::true_type(), std::true_type());
         break;
     }

--- a/include/boost/json/basic_parser_impl.hpp
+++ b/include/boost/json/basic_parser_impl.hpp
@@ -753,6 +753,7 @@ template<
     bool AllowTrailing_,
     bool AllowBadUTF8_*/>
 const char*
+basic_parser<Handler>::
 resume_value(const char* p,
     std::integral_constant<bool, AllowComments_> allow_comments,
     /*std::integral_constant<bool, AllowTrailing_>*/ bool allow_trailing,

--- a/include/boost/json/basic_parser_impl.hpp
+++ b/include/boost/json/basic_parser_impl.hpp
@@ -744,7 +744,7 @@ loop:
             }
         }
     }
-    return resume_value(p, stack_empty, allow_comments, allow_trailing, allow_bad_utf8, allow_bad_utf16);
+    return resume_value(p, allow_comments, allow_trailing, allow_bad_utf8, allow_bad_utf16);
 }
 
 template<class Handler>
@@ -754,7 +754,6 @@ template<
     bool AllowBadUTF8_*/>
 const char*
 resume_value(const char* p,
-    std::integral_constant<bool, StackEmpty_> stack_empty,
     std::integral_constant<bool, AllowComments_> allow_comments,
     /*std::integral_constant<bool, AllowTrailing_>*/ bool allow_trailing,
     /*std::integral_constant<bool, AllowBadUTF8_>*/ bool allow_bad_utf8,

--- a/include/boost/json/parse_options.hpp
+++ b/include/boost/json/parse_options.hpp
@@ -118,6 +118,22 @@ struct parse_options
 
     /** Non-standard extension option
 
+        Allow invalid UTF-16 surrogate pairs to appear
+        in strings. When enabled, the parser will not
+        strictly validate the correctness of UTF-16
+        encoding, allowing for the presence of illegal
+        leading or trailing surrogates. In case of
+        invalid sequences, the parser will replace them
+        with the Unicode replacement character.
+
+        @note Enabling this option may result in the
+        parsing of invalid UTF-16 sequences without
+        error, potentially leading to the loss of information.
+    */
+    bool allow_invalid_utf16 = false;
+
+    /** Non-standard extension option
+
         Allow `Infinity`, `-Infinity`, and `NaN` JSON literals. These values
         are produced by some popular JSON implementations for positive
         infinity, negative infinity and NaN special numbers respectively.

--- a/test/basic_parser.cpp
+++ b/test/basic_parser.cpp
@@ -1442,7 +1442,7 @@ public:
         TEST_GOOD_EXT("{\"command\":\"\\uDF3E\\uDEC2\"}", opt);  // Illegal leading surrogate
         TEST_GOOD_EXT("{\"command\":\"\\uD83D\\uD83D\"}", opt);  // Illegal trailing surrogate
         TEST_GOOD_EXT("{\"command\":\"\\uDF3E\\uD83D\"}", opt);  // Illegal leading & trailing surrogate
-        TEST_GOOD_EXT("{\"command\":\"\\uD83D\"}", opt);        // Half a surrogate (Valid leading surrogate)
+        TEST_GOOD_EXT("{\"command\":\"\\uD83D\"}", opt);         // Half a surrogate (Valid leading surrogate)
         TEST_GOOD_EXT("{\"command\":\"\\uDF3E\"}", opt);         // Half a surrogate (Illegal leading surrogate)
     }
 

--- a/test/basic_parser.cpp
+++ b/test/basic_parser.cpp
@@ -1426,6 +1426,27 @@ public:
     }
 
     void
+    testUTF16Validation()
+    {
+        // Invalid surrogate pair cases
+        TEST_BAD("{\"command\":\"\\uDF3E\\uDEC2\"}");     // Illegal leading surrogate
+        TEST_BAD("{\"command\":\"\\uD83D\\uD83D\"}");     // Illegal trailing surrogate
+        TEST_BAD("{\"command\":\"\\uDF3E\\uD83D\"}");     // Illegal leading & trailing surrogate
+        TEST_BAD("{\"command\":\"\\uD83D\"}");            // Half a surrogate (Valid leading surrogate)
+        TEST_BAD("{\"command\":\"\\uDF3E\"}");            // Half a surrogate (Illegal leading surrogate)
+
+        // Allow invalid UTF-16
+        parse_options opt;
+        opt.allow_invalid_utf16 = true;
+
+        TEST_GOOD_EXT("{\"command\":\"\\uDF3E\\uDEC2\"}", opt);  // Illegal leading surrogate
+        TEST_GOOD_EXT("{\"command\":\"\\uD83D\\uD83D\"}", opt);  // Illegal trailing surrogate
+        TEST_GOOD_EXT("{\"command\":\"\\uDF3E\\uD83D\"}", opt);  // Illegal leading & trailing surrogate
+        TEST_GOOD_EXT("{\"command\":\"\\uD83D\"}", opt);        // Half a surrogate (Valid leading surrogate)
+        TEST_GOOD_EXT("{\"command\":\"\\uDF3E\"}", opt);         // Half a surrogate (Illegal leading surrogate)
+    }
+
+    void
     testMaxDepth()
     {
         {
@@ -1740,6 +1761,7 @@ public:
         testAllowTrailing();
         testComments();
         testUTF8Validation();
+        testUTF16Validation();
         testMaxDepth();
         testNumberLiteral();
         testStickyErrors();

--- a/test/doc_parsing.cpp
+++ b/test/doc_parsing.cpp
@@ -1,4 +1,4 @@
-//
+﻿//
 // Copyright (c) 2019 Vinnie Falco (vinnie.falco@gmail.com)
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -74,6 +74,7 @@ parse_options opt;                                  // all extensions default to
 opt.allow_comments = true;                          // permit C and C++ style comments to appear in whitespace
 opt.allow_trailing_commas = true;                   // allow an additional trailing comma in object and array element lists
 opt.allow_invalid_utf8 = true;                      // skip utf-8 validation of keys and strings
+opt.allow_invalid_utf16 = true;                     // replace invalid surrogate pair UTF-16 code point(s) with the Unicode replacement character
 
 value jv = parse( "[1,2,3,] // comment ", storage_ptr(), opt );
 //]
@@ -87,6 +88,11 @@ value jv = parse( "[1,2,3,] // comment ", storage_ptr(),
         .allow_comments = true,             // permit C and C++ style comments to appear in whitespace
         .allow_trailing_commas = true,      // allow a trailing comma in object and array lists
         .allow_invalid_utf8 = true          // skip utf-8 validation of keys and strings
+    });
+
+value jv = parse( "{\"command\":\"\\uDF3E\\uDEC2\"}", storage_ptr(),
+    {
+        .allow_invalid_utf16 = true;        // replace illegal leading surrogate pair with ��
     });
 //]
 #endif


### PR DESCRIPTION
**Motivation**

- Boost library provides parsing and serialization algorithms to transform JSON to and from the [value](https://www.boost.org/doc/libs/develop/libs/json/doc/html/json/ref/boost__json__value.html) container as needed.
- The current version of the boost JSON library includes an option `parse_options::allow_invalid_utf8` to control the treatment of unescaped UTF-8 code units, allowing users to disable the validation of UTF-8 code points.
- It lacks a similar capability for dealing with invalid UTF-16 surrogate pairs. This limitation becomes apparent when users encounter scenarios involving UTF-16 encoded data with mismatched or out-of-range surrogate pairs, where the existing functionality does not provide adequate support or validation mechanisms.
- Therefore, extending this functionality to encompass invalid UTF-16 surrogate pairs is necessary to ensure comprehensive handling of different UTF encoding scenarios and enhance the library's robustness and versatility in parsing and serialization tasks involving UTF-16 encoded JSON data.


**Design**

- The introduction of the `parse_options::allow_invalid_utf16` option grants the allowance of invalid UTF-16 surrogate pairs in strings processed by the parser.
- Activation of this option relaxes the parser's strict validation of UTF-16 encoding, allowing for the existence of illegal leading or trailing surrogates.
- When the option is activated, the parser refrains from raising errors for invalid UTF-16 sequences. Instead, it replaces these invalid sequences with the Unicode replacement character.